### PR TITLE
feat: create typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+import type {
+  SpokAssertions,
+  SpokConfig,
+  Specifications,
+  SpokFunctionAny,
+  Assert
+} from 'spok/dist/types'
+import { ExpectFn } from 'spok/dist/adapter-chai-expect'
+
+declare type SpokFunction<Subject> = (currentSubject: Subject) => void
+
+declare type SpokHelper<Subject = any> = (
+  specifications: Specifications<Subject>
+) => SpokFunction<Subject>
+
+declare const Spok: SpokHelper &
+  SpokAssertions &
+  SpokConfig & {
+    any: SpokFunctionAny
+    adapters: {
+      chaiExpect: (expectFn: ExpectFn<any>) => Assert
+    }
+  }
+
+export = Spok


### PR DESCRIPTION
Creates the typescript definitions, correctly shadowing fields and satisfying cypress's chaining system